### PR TITLE
[EPO-402] Allow prepuller to be configured for other images

### DIFF
--- a/prepuller/Dockerfile
+++ b/prepuller/Dockerfile
@@ -3,13 +3,14 @@ USER root
 RUN  yum install -y cronie epel-release
 RUN  yum install -y python34
 RUN  yum -y update
+COPY run-cron.sh /usr/bin/run-cron.sh
 COPY get_builds.py /usr/bin/get_builds
 COPY node_update /usr/bin/node_update
 COPY imagepuller /etc/cron.hourly/local01-imagepuller
 COPY imagepurger /etc/cron.daily/local01-imagepurger
-RUN  chmod 0755 /usr/bin/get_builds /usr/bin/node_update \
+RUN  chmod 0755 /usr/bin/get_builds /usr/bin/run-cron.sh /usr/bin/node_update \
       /etc/cron.hourly/local01-imagepuller /etc/cron.daily/local01-imagepurger
-CMD [ "/usr/sbin/crond", "-n", "-x",  "sch,proc" ]
+CMD [ "/usr/bin/run-cron.sh" ]
 LABEL      description="jupyterlab demo: imageprepuller" \
              name="lsstsqre/prepuller" \
              version="0.0.4"

--- a/prepuller/imagepuller
+++ b/prepuller/imagepuller
@@ -1,14 +1,15 @@
 #!/bin/sh
-PATH=/sbin:/bin:/usr/sbin:/usr/bin
 MAILTO=""
-LAB_REPO_HOST=${1:-"hub.docker.com"}
-LAB_REPO_OWNER=${1:-"lsstsqre"}
-LAB_REPO_NAME=${1:-"jld-lab"}
+LAB_REPO_HOST=${LAB_REPO_HOST:-"hub.docker.com"}
+LAB_REPO_OWNER=${LAB_REPO_OWNER:-"lsstsqre"}
+LAB_REPO_NAME=${LAB_REPO_NAME:-"jld-lab"}
 RANDOM_DELAY=30 # So they don't all run at once.
 export RANDOM_DELAY
 if [ -n "${LAB_IMAGE}" ]; then
     LAB_CONTAINER_NAMES="${LAB_IMAGE}"
+    echo "Pulling image ${LAB_IMAGE}"
 else
+    echo "Pulling image ${LAB_REPO_OWNER}:${LAB_REPO_NAME}from ${LAB_REPO_HOST}!"
     get_builds -r ${LAB_REPO_HOST} \
 	       -o ${LAB_REPO_OWNER} \
 	       -n ${LAB_REPO_NAME} \

--- a/prepuller/imagepurger
+++ b/prepuller/imagepurger
@@ -1,5 +1,6 @@
 #!/bin/sh
-PATH=/sbin:/bin:/usr/sbin:/usr/bin
 MAILTO=""
 RANDOM_DELAY=90 # So they don't all run at once.
-node_update -g /usr/bin/get_builds
+LAB_REPO_OWNER=${LAB_REPO_OWNER:-"lsstsqre"}
+LAB_REPO_NAME=${LAB_REPO_NAME:-"jld-lab"}
+node_update -g /usr/bin/get_builds -n ${LAB_REPO_OWNER}/${LAB_REPO_NAME}

--- a/prepuller/run-cron.sh
+++ b/prepuller/run-cron.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Cron doesn't forward along it's environment variables from
+# when it is started, but it should respect /etc/environment.
+# Stuff our environment variables from starting in there.
+/usr/bin/env > /etc/environment
+exec /usr/sbin/crond -n -x sch,proc


### PR DESCRIPTION
We need to persist the environment that is the main environment for
the container.  Cron runs in its own environment, which includes
/etc/environment but not the environment where it is started.

Also plumbed through the environment variables to the scripts.