### PR TITLE
inherit devtoolset-6 from base image instead of explicit setup

### DIFF
--- a/jupyterlab/Dockerfile.template
+++ b/jupyterlab/Dockerfile.template
@@ -3,7 +3,7 @@ USER root
 RUN  yum install -y epel-release
 RUN  yum repolist
 RUN  yum -y  upgrade
-RUN  yum -y install gcc \
+RUN  yum -y install \
       git sudo \
       python-devel http-parser nodejs \
       make zlib-devel perl-ExtUtils-MakeMaker gettext \

--- a/jupyterlab/Dockerfile.template
+++ b/jupyterlab/Dockerfile.template
@@ -13,7 +13,6 @@ RUN  yum -y install \
       texlive-adjustbox
 # Python 3.6, tkinter, and git: install from SCL
 RUN  yum -y install centos-release-scl && \
-     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
      yum -y install rh-git29 devtoolset-6 rh-python36-python-tkinter \
       rh-python36
 # Install git-lfs repo and then git-lfs

--- a/jupyterlab/Dockerfile.template
+++ b/jupyterlab/Dockerfile.template
@@ -13,7 +13,7 @@ RUN  yum -y install \
       texlive-adjustbox
 # Python 3.6, tkinter, and git: install from SCL
 RUN  yum -y install centos-release-scl && \
-     yum -y install rh-git29 devtoolset-6 rh-python36-python-tkinter \
+     yum -y install rh-git29 rh-python36-python-tkinter \
       rh-python36
 # Install git-lfs repo and then git-lfs
 RUN  curl -s \

--- a/jupyterlab/local06-scl.sh
+++ b/jupyterlab/local06-scl.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-for i in rh-git29 devtoolset-6 rh-python36; do
+for i in rh-git29 rh-python36; do
     source scl_source enable ${i}
 done


### PR DESCRIPTION
As the scl provided compiler from the base image may change, this will avoid
possible fallout if/when that happens.